### PR TITLE
Update package.json for openssl compatibility.

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-tree-0f24e2f00.yml
+++ b/.github/workflows/azure-static-web-apps-mango-tree-0f24e2f00.yml
@@ -14,6 +14,8 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
       - uses: actions/checkout@v2
         with:
@@ -36,6 +38,8 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
       - name: Close Pull Request
         id: closepullrequest

--- a/.github/workflows/azure-static-web-apps-mango-tree-0f24e2f00_TimerTrigger.yml
+++ b/.github/workflows/azure-static-web-apps-mango-tree-0f24e2f00_TimerTrigger.yml
@@ -9,6 +9,8 @@ jobs:
   build_and_deploy_job:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
       - uses: actions/checkout@v2
         with:

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "set NODE_OPTIONS=--openssl-legacy-provider && next dev",
     "build": "run-s build:posts build:next",
     "build:posts": "ts-node --project tsconfig.builder.json ./src/builder/posts.ts",
-    "build:next": "next build && next export",
-    "start": "next start"
+    "build:next": "set NODE_OPTIONS=--openssl-legacy-provider && next build && next export",
+    "start": "set NODE_OPTIONS=--openssl-legacy-provider && next start"
   },
   "dependencies": {
     "dayjs": "^1.9.3",


### PR DESCRIPTION
## 現象
GitHub Actions の日次更新パイプラインが失敗していました。
具体的には、yarn build を実行した際に下記のエラーが発生していました。

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:79:19)
    at Object.createHash (node:crypto:139:10)
    at module.exports (C:\develop\team-blog-hub\node_modules\webpack\lib\util\createHash.js:135:53)
    at NormalModule._initBuildHash (C:\develop\team-blog-hub\node_modules\webpack\lib\NormalModule.js:417:16)
    at handleParseError (C:\develop\team-blog-hub\node_modules\webpack\lib\NormalModule.js:471:10)
    at C:\develop\team-blog-hub\node_modules\webpack\lib\NormalModule.js:503:5
    at C:\develop\team-blog-hub\node_modules\webpack\lib\NormalModule.js:358:12
    at C:\develop\team-blog-hub\node_modules\loader-runner\lib\LoaderRunner.js:373:3
    at iterateNormalLoaders (C:\develop\team-blog-hub\node_modules\loader-runner\lib\LoaderRunner.js:214:10)
    at Array.<anonymous> (C:\develop\team-blog-hub\node_modules\loader-runner\lib\LoaderRunner.js:205:4) {
  opensslErrorStack: [
    'error:03000086:digital envelope routines::initialization error',
    'error:0308010C:digital envelope routines::unsupported'
  ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'

## 原因
OpenSSL がバージョンアップしたことにより、旧バージョンとの互換性がなくなったことでした。

## 対応
環境変数で旧バージョンの OpenSSL を使うように指定しました。
