### PR TITLE
adjust build timeout.

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-tree-0f24e2f00.yml
+++ b/.github/workflows/azure-static-web-apps-mango-tree-0f24e2f00.yml
@@ -33,6 +33,7 @@ jobs:
           api_location: "" # Api source code path - optional
           output_location: "out" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
+          build_timeout_in_minutes: 30
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps-mango-tree-0f24e2f00_TimerTrigger.yml
+++ b/.github/workflows/azure-static-web-apps-mango-tree-0f24e2f00_TimerTrigger.yml
@@ -28,3 +28,4 @@ jobs:
           api_location: "" # Api source code path - optional
           output_location: "out" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
+          build_timeout_in_minutes: 30


### PR DESCRIPTION
日次で実行している Titmer Trigger が Azure Static Web Apps のタイムアウトで失敗することが増えてきたので、デフォルトの15分を30分に延長して経過を見ることにします。
https://learn.microsoft.com/ja-jp/azure/static-web-apps/build-configuration?tabs=aat&pivots=github-actions#extend-build-timeout